### PR TITLE
feat: add geth, mev-boost and mev-geth

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ just fmt
 - [prysm](https://github.com/prysmaticlabs/prysm):
   - beacon-chain: `nix run .#beacon-chain`
   - client-stats: `nix run .#client-stats`
+  - prysmctl: `nix run .#prysmctl`
   - validator: `nix run .#validator`
 - [teku](https://github.com/ConsenSys/teku): `nix run .#teku`
 - [lighthouse](https://github.com/sigp/lighthouse): `nix run .#lighthouse`
@@ -147,7 +148,19 @@ just fmt
 
 - [besu](https://github.com/hyperledger/besu): `nix run .#besu`
 - [erigon](https://github.com/ledgerwatch/erigon): `nix run .#erigon`
-- [geth](https://github.com/ethereum/go-ethereum): `nix run .#geth`
+- [geth](https://github.com/ethereum/go-ethereum):
+  - abidump: `nix run .#abidump`
+  - abigen: `nix run .#abigen`
+  - bootnode: `nix run .#bootnode`
+  - clef: `nix run .#clef`
+  - devp2p: `nix run .#devp2p`
+  - ethkey: `nix run .#ethkey`
+  - evm: `nix run .#evm`
+  - faucet: `nix run .#faucet`
+  - geth: `nix run .#geth`
+  - rlpdump: `nix run .#rlpdump`
+- [mev-geth](https://github.com/flashbots/mev-geth): `nix run .#mev-geth`
+- [mev-boost](https://github.com/flashbots/mev-boost/): `nix run .#mev-boost`
 
 #### Utilities / Tools / Other
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,11 @@
   };
 
   inputs = {
+    # packages
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixlib.url = github:nix-community/nixpkgs.lib;
 
+    # libraries
     fu.url = "github:numtide/flake-utils";
     fup = {
       url = "github:gytis-ivaskevicius/flake-utils-plus";
@@ -95,8 +97,14 @@
         drv = erigon;
       };
       geth = l.mkApp {
+        drv = geth;
+      };
+      mev-boost = l.mkApp {
+        drv = mev-boost;
+      };
+      mev-geth = l.mkApp {
         name = "geth";
-        drv = go-ethereum;
+        drv = mev-geth;
       };
 
       # utils

--- a/flake.nix
+++ b/flake.nix
@@ -69,22 +69,26 @@
   in {
     # nix run .#<app>
     apps = with pkgs; {
-      # consensus clients
+      # consensus clients / prysm
       beacon-chain = l.mkApp {
         name = "beacon-chain";
-        drv = prysm;
-      };
-      client-stats = l.mkApp {
-        name = "client-stats";
         drv = prysm;
       };
       validator = l.mkApp {
         name = "validator";
         drv = prysm;
       };
+      client-stats = l.mkApp {
+        name = "client-stats";
+        drv = prysm;
+      };
+
+      # consensus / teku
       teku = l.mkApp {
         drv = teku;
       };
+
+      # consensus / lighthouse
       lighthouse = l.mkApp {
         drv = lighthouse;
       };
@@ -107,9 +111,57 @@
         drv = mev-geth;
       };
 
-      # utils
+      # utils / ethdo
       ethdo = l.mkApp {
         drv = ethdo;
+      };
+
+      # utils / geth
+      abidump = l.mkApp {
+        name = "abidump";
+        drv = geth;
+      };
+      abigen = l.mkApp {
+        name = "abigen";
+        drv = geth;
+      };
+      bootnode = l.mkApp {
+        name = "bootnode";
+        drv = geth;
+      };
+      clef = l.mkApp {
+        name = "clef";
+        drv = geth;
+      };
+      devp2p = l.mkApp {
+        name = "devp2p";
+        drv = geth;
+      };
+      ethkey = l.mkApp {
+        name = "ethkey";
+        drv = geth;
+      };
+      evm = l.mkApp {
+        name = "evm";
+        drv = geth;
+      };
+      faucet = l.mkApp {
+        name = "faucet";
+        drv = geth;
+      };
+      rlpdump = l.mkApp {
+        name = "rlpdump";
+        drv = geth;
+      };
+
+      # utils / prysm
+      keystores = l.mkApp {
+        name = "keystores";
+        drv = prysm;
+      };
+      prysmctl = l.mkApp {
+        name = "prysmctl";
+        drv = prysm;
       };
     };
 

--- a/overlays.nix
+++ b/overlays.nix
@@ -6,6 +6,13 @@ _: prev: {
 
   # execution clients
   erigon = prev.callPackage ./packages/clients/execution/erigon {};
+  inherit
+    (prev.callPackage ./packages/clients/execution/geth {})
+    buildGeth
+    geth
+    mev-boost
+    mev-geth
+    ;
 
   # utils
   ethdo = prev.callPackage ./packages/utils/ethdo {};

--- a/packages/clients/consensus/prysm/default.nix
+++ b/packages/clients/consensus/prysm/default.nix
@@ -4,21 +4,34 @@
   buildGoModule,
   fetchFromGitHub,
   libelf,
+  lib,
 }:
 buildGoModule rec {
   pname = "prysm";
-  version = "3.0.0";
+  version = "3.1.1";
 
   src = fetchFromGitHub {
     owner = "prysmaticlabs";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-316bJy4outYfCs70bKL9wwQ/YTBZLt45CusBsI1lFxE=";
+    hash = "sha256-iy+UayBKEwcgmJT2uuO1q9vmrABdeXzEMTxEVbUGQiA=";
   };
 
-  vendorSha256 = "sha256-Tv59UG3i9Wpv9Vf012oC2EKgtYj5FiWaySdU3qNeYpw=";
+  vendorSha256 = "sha256-gy/8tHuDl5win03pE/+61um7EU3pQEj1Xim94LwK5uE=";
 
   buildInputs = [bls blst libelf];
 
+  subPackages = [
+    "cmd/beacon-chain"
+    "cmd/client-stats"
+    "cmd/prysmctl"
+    "cmd/validator"
+  ];
+
   doCheck = false;
+
+  meta = {
+    description = "Go implementation of Ethereum proof of stake";
+    homepage = "https://github.com/prysmaticlabs/prysm";
+  };
 }

--- a/packages/clients/consensus/prysm/default.nix
+++ b/packages/clients/consensus/prysm/default.nix
@@ -4,7 +4,6 @@
   buildGoModule,
   fetchFromGitHub,
   libelf,
-  lib,
 }:
 buildGoModule rec {
   pname = "prysm";

--- a/packages/clients/execution/geth/default.nix
+++ b/packages/clients/execution/geth/default.nix
@@ -1,0 +1,109 @@
+{
+  blst,
+  buildGoModule,
+  fetchFromGitHub,
+  lib,
+}: let
+  buildGeth = {
+    name,
+    version,
+    owner,
+    repo,
+    sha256,
+    vendorSha256 ? null,
+    bins ? [
+      "abidump"
+      "abigen"
+      "bootnode"
+      "clef"
+      "devp2p"
+      "ethkey"
+      "evm"
+      "faucet"
+      "geth"
+      "rlpdump"
+    ],
+    ...
+  } @ attrs: let
+    attrs' = builtins.removeAttrs attrs ["name" "version" "owner" "repo" "sha256" "vendorSha256" "bins"];
+  in
+    buildGoModule ({
+        inherit name vendorSha256;
+
+        src = fetchFromGitHub {
+          inherit owner repo sha256;
+          rev = "v${version}";
+        };
+
+        ldflags = ["-s" "-w"];
+
+        doCheck = false;
+
+        # Move binaries to separate outputs and symlink them back to $out
+        postInstall = lib.concatStringsSep "\n" (
+          builtins.map (bin: "mkdir -p \$${bin}/bin && mv $out/bin/${bin} \$${bin}/bin/ && ln -s \$${bin}/bin/${bin} $out/bin/") bins
+        );
+
+        outputs = ["out"] ++ bins;
+
+        subPackages = [
+          "cmd/abidump"
+          "cmd/abigen"
+          "cmd/bootnode"
+          "cmd/checkpoint-admin"
+          "cmd/clef"
+          "cmd/devp2p"
+          "cmd/ethkey"
+          "cmd/evm"
+          "cmd/faucet"
+          "cmd/geth"
+          "cmd/p2psim"
+          "cmd/puppeth"
+          "cmd/rlpdump"
+          "cmd/utils"
+        ];
+
+        # Following upstream: https://github.com/ethereum/go-ethereum/blob/v1.10.23/build/ci.go#L218
+        tags = ["urfave_cli_no_docs"];
+
+        meta = with lib; {
+          homepage = "https://geth.ethereum.org/";
+          description = "Official golang implementation of the Ethereum protocol";
+          license = with licenses; [lgpl3Plus gpl3Plus];
+        };
+      }
+      // attrs');
+in {
+  inherit buildGeth;
+
+  geth = buildGeth {
+    name = "geth";
+    version = "1.10.23";
+    owner = "ethereum";
+    repo = "go-ethereum";
+    sha256 = "sha256-1fEmtbHKrjuyIVrGr/vTudZ99onkNjEMvyBJt4I8KK4=";
+    vendorSha256 = "sha256-Dj+xN8lr98LJyYr2FwJ7yUIJkUeUrr1fkcbj4hShJI0=";
+  };
+
+  mev-boost = buildGeth {
+    name = "mev-boost";
+    version = "0.8.2";
+    owner = "flashbots";
+    repo = "mev-boost";
+    sha256 = "sha256-Cx5BL8ZR54MsuAvfVgUpC4+VMDS6gLUGgRa+sT+x3nw=";
+    vendorSha256 = "sha256-HKp3zCOOiRmn25cSKlAo6/S/bqKFBmMzRbyDDwdQkzc=";
+    subPackages = ["cmd/mev-boost"];
+    buildInputs = [blst];
+    bins = [];
+  };
+
+  mev-geth = buildGeth {
+    name = "mev-geth";
+    version = "1.10.19-mev0.6.1";
+    owner = "flashbots";
+    repo = "mev-geth";
+    sha256 = "sha256-8czmwlbUHx2yR4qBlmABO/ywXGUZYYmL5wXlhxUxAqk=";
+    vendorSha256 = "sha256-yOR/XLY54R2w5Dz/xDZ9mDzvYOobUxuxu355jqVPm2k=";
+    bins = ["geth"];
+  };
+}


### PR DESCRIPTION
# Description

This PR brings the following execution clients:

- [X]  [mev-boost](https://github.com/flashbots/mev-boost)
- [X] [mev-geth](https://github.com/flashbots/mev-geth)
- [x] [geth](https://github.com/ethereum/go-ethereum/)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update